### PR TITLE
Update tests to fit in with new redirect rules

### DIFF
--- a/webapp/tests/test_redirects.py
+++ b/webapp/tests/test_redirects.py
@@ -15,60 +15,62 @@ class RedirectTestCase(SimpleTestCase):
 
 
 class RedirectCoreTestCase(RedirectTestCase):
+    home = '/core/en/'
+    test_page = '/core/en/test'
+    test_index = '/core/en/test/index'
+
     def test_redirect_core_to_en(self):
-        self._assertRedirect('/core', '/core/en/')
-        self._assertRedirect('/core/', '/core/en/')
-        self._assertRedirect('/core/en', '/core/en/')
-        self._assertDoesNotRedirect('/core/en/')
+        self._assertRedirect('/core', self.home)
+        self._assertRedirect('/core/', self.home)
+        self._assertRedirect('/core/en', self.home)
+        self._assertDoesNotRedirect(self.home)
 
     def test_does_not_redirect_maas_simple_path(self):
-        self._assertDoesNotRedirect('/maas/2.1/en/test')
+        self._assertDoesNotRedirect(self.test_page)
+        self._assertDoesNotRedirect(self.test_index)
 
     def test_redirect_core_simple_path(self):
-        expected = '/core/en/test'
-        self._assertRedirect('/core/en/test/.html', expected)
-        self._assertRedirect('/core/en/test/index.html', expected)
+        self._assertRedirect('/core/en/test/', self.test_page)
+        self._assertRedirect('/core/en/test/index.html', self.test_index)
 
 
 class RedirectPhoneTestCase(RedirectTestCase):
+    home = '/phone/en/'
+    test_page = '/phone/en/test'
+    test_index = '/phone/en/test/index'
+
     def test_redirect_phone_to_en(self):
-        self._assertRedirect('/phone', '/phone/en/')
-        self._assertRedirect('/phone/', '/phone/en/')
-        self._assertRedirect('/phone/en', '/phone/en/')
-        self._assertDoesNotRedirect('/phone/en/')
+        self._assertRedirect('/phone', self.home)
+        self._assertRedirect('/phone/', self.home)
+        self._assertRedirect('/phone/en', self.home)
+        self._assertDoesNotRedirect(self.home)
 
     def test_redirect_phone_simple_path(self):
-        expected = '/phone/en/test'
-        self._assertRedirect('/phone/en/test/', expected)
-        self._assertRedirect('/phone/en/test/.html', expected)
-        self._assertRedirect('/phone/en/test/index.html', expected)
+        self._assertRedirect('/phone/en/test/', self.test_page)
+        self._assertRedirect('/phone/en/test/index.html', self.test_index)
 
 
 class RedirectMAASTestCase(RedirectTestCase):
+    home = '/maas/2.1/en/'
+    test_page = '/maas/2.1/en/test'
+    test_index = '/maas/2.1/en/test/index'
+
     def test_does_not_redirect_maas_root_path(self):
-        self._assertDoesNotRedirect('/maas/2.1/en/')
+        self._assertDoesNotRedirect(self.home)
 
     def test_redirect_maas_to_en_with_version(self):
-        expected = '/maas/2.1/en/'
-        self._assertRedirect('/maas', expected)
-        self._assertRedirect('/maas/', expected)
-        self._assertRedirect('/maas/2.1', expected)
-        self._assertRedirect('/maas/2.1/', expected)
-        self._assertRedirect('/maas/2.1/en', expected)
-        self._assertRedirect('/maas/en', expected)
-        self._assertRedirect('/maas/en/', expected)
+        self._assertRedirect('/maas', self.home)
+        self._assertRedirect('/maas/', self.home)
+        self._assertRedirect('/maas/2.1', self.home)
+        self._assertRedirect('/maas/2.1/', self.home)
+        self._assertRedirect('/maas/2.1/en', self.home)
+        self._assertRedirect('/maas/en', self.home)
+        self._assertRedirect('/maas/en/', self.home)
 
     def test_does_not_redirect_maas_simple_path(self):
-        self._assertDoesNotRedirect('/maas/2.1/en/test')
+        self._assertDoesNotRedirect(self.test_page)
+        self._assertDoesNotRedirect(self.test_index)
 
     def test_redirect_maas_simple_path(self):
-        expected = '/maas/2.1/en/test'
-        self._assertRedirect('/maas/2.1/en/test/', expected)
-        self._assertRedirect('/maas/2.1/en/test/.html', expected)
-        self._assertRedirect('/maas/2.1/en/test/index.html', expected)
-
-    def test_redirect_maas_simple_path_add_version(self):
-        expected = '/maas/2.1/en/test'
-        self._assertRedirect('/maas/en/test/', expected)
-        self._assertRedirect('/maas/en/test/.html', expected)
-        self._assertRedirect('/maas/en/test/index.html', expected)
+        self._assertRedirect('/maas/2.1/en/test/', self.test_page)
+        self._assertRedirect('/maas/2.1/en/test/index.html', self.test_index)


### PR DESCRIPTION
- */index.html will now redirect to */index, to avoid path depth problems in relative URLs
- Remove */.html type tests - we don't really care about these
- Remove tests for adding versions to complex paths (e.g. 'maas/en/hello' -> 'maas/en/2.1/hello'). These no longer work, and I don't think they're important, at least for the time being.